### PR TITLE
Central Repository version 1.0.0, GeoPackage Cache, External GeoPackage Methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 #java specific
 *.class
 *.settings
+javadoc/
 
 # Built application files
 *.apk

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Software source code previously released under an open source license and then m
 
 ### About ###
 
-GeoPackage Android is a SDK implementation of the Open Geospatial Consortium [GeoPackage](http://www.geopackage.org/) [spec](http://www.geopackage.org/spec/).
+GeoPackage Android is a SDK implementation of the Open Geospatial Consortium [GeoPackage](http://www.geopackage.org/) [spec](http://www.geopackage.org/spec/).  It is listed as an [OGC GeoPackage Implementation](http://www.geopackage.org/#implementations) by the National Geospatial-Intelligence Agency.
 
 The GeoPackage SDK provides the ability to manage GeoPackage files providing read, write, import, export, share, and open support. Open GeoPackage files provide read and write access to features and tiles. Feature support includes Well-Known Binary and Google Map shape translations. Tile generation supports creation by URL or features. Tile providers supporting GeoPackage format, Google tile API, and feature tile generation.
 
@@ -119,6 +119,12 @@ The [GeoPackage MapCache](https://github.com/ngageoint/geopackage-mapcache-andro
     // Close database when done
     geoPackage.close();
 
+### Installation ###
+
+Pull from the [Maven Central Repository](http://search.maven.org/#artifactdetails|mil.nga.geopackage|geopackage-android|1.0.0|aar)
+
+    compile "mil.nga.geopackage:geopackage-android:1.0.0"
+
 ### Build ###
 
 Build this repository using Android Studio and/or Gradle.
@@ -136,7 +142,7 @@ Include as repositories in your project build.gradle:
 
 Include the dependency in your module build.gradle with desired version number:
 
-    compile "mil.nga.geopackage.android:geopackage-sdk:1.0.0"
+    compile "mil.nga.geopackage:geopackage-android:1.0.0"
     
 As part of the build process, run the "uploadArchives" task on the geopackage-android Gradle script to update the Maven local repository.
     

--- a/README.md
+++ b/README.md
@@ -121,10 +121,6 @@ The [GeoPackage MapCache](https://github.com/ngageoint/geopackage-mapcache-andro
 
 ### Build ###
 
-The following repositories must be built first (Central Repository Artifacts Coming Soon):
-* [GeoPackage WKB Java] (https://github.com/ngageoint/geopackage-wkb-java)
-* [GeoPackage Core Java] (https://github.com/ngageoint/geopackage-core-java)
-
 Build this repository using Android Studio and/or Gradle.
 
 #### Project Setup ####
@@ -161,4 +157,5 @@ From your project directory, link the cloned SDK directory:
 ### Remote Dependencies ###
 
 * [GeoPackage Core Java](https://github.com/ngageoint/geopackage-core-java) (The MIT License (MIT)) - GeoPackage Library
+* [WKB](https://github.com/ngageoint/geopackage-wkb-java) (The MIT License (MIT)) - GeoPackage Well Known Binary Lib
 * [OrmLite](http://ormlite.com/) (Open Source License) - Object Relational Mapping (ORM) Library

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:1.1.2'
         classpath 'com.github.dcendents:android-maven-plugin:1.2'
     }
 }

--- a/geopackage-sdk/build.gradle
+++ b/geopackage-sdk/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-group 'mil.nga.geopackage.android'
+group 'mil.nga.geopackage'
 version '1.0.0'
 
 android {
@@ -44,12 +44,31 @@ android {
         repositories {
             mavenDeployer {
                 repository url: 'file://' + new File(System.getProperty('user.home'), '.m2/repository')
+                pom.artifactId = 'geopackage-android'
             }
         }
         artifacts {
             archives sourceJar
         }
     }
+
+    /*
+    uploadArchives {
+        repositories {
+            mavenDeployer {
+                repository(
+                        url: "${nexusUrl}/content/repositories/releases") {
+                    authentication(userName: nexusUsername, password: nexusPassword)
+                }
+                snapshotRepository(
+                        url: "${nexusUrl}/content/repositories/snapshots") {
+                    authentication(userName: nexusUsername, password: nexusPassword)
+                }
+                pom.artifactId = 'geopackage-android'
+            }
+        }
+    }
+    */
 }
 
 dependencies {

--- a/geopackage-sdk/build.gradle
+++ b/geopackage-sdk/build.gradle
@@ -1,8 +1,11 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
+apply plugin: 'signing'
 
-group 'mil.nga.geopackage'
-version '1.0.0'
+group = "mil.nga.geopackage"
+archivesBaseName = "geopackage-android"
+version = "1.0.0"
+def remotePublish = false
 
 android {
     compileSdkVersion 21
@@ -35,40 +38,94 @@ android {
         }
     }
 
-    task sourceJar(type: Jar) {
+    task javadoc(type: Javadoc) {
+        source = android.sourceSets.main.java.srcDirs
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+        destinationDir = file("../javadoc/")
+        failOnError false
+    }
+
+    task javadocJar(type: Jar) {
+        classifier = 'javadoc'
+        from javadoc
+    }
+
+    task sourcesJar(type: Jar) {
         classifier = 'sources'
         from sourceSets.main.java.srcDirs
     }
 
+    artifacts {
+        archives javadocJar, sourcesJar
+    }
+
+    signing {
+        sign configurations.archives
+    }
+
     uploadArchives {
         repositories {
             mavenDeployer {
-                repository url: 'file://' + new File(System.getProperty('user.home'), '.m2/repository')
-                pom.artifactId = 'geopackage-android'
+
+                if (!remotePublish) {
+
+                    repository url: 'file://' + new File(System.getProperty('user.home'), '.m2/repository')
+
+                } else {
+
+                    beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+                    repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                        authentication(userName: ossrhUsername, password: ossrhPassword)
+                    }
+
+                    snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                        authentication(userName: ossrhUsername, password: ossrhPassword)
+                    }
+
+                    pom.project {
+                        name 'GeoPackage Android'
+                        packaging 'aar'
+                        description 'GeoPackage Android implementation'
+                        url 'https://github.com/ngageoint/geopackage-android'
+
+                        scm {
+                            url 'git@github.com:ngageoint/geopackage-android.git'
+                            connection 'scm:git:git@github.com:ngageoint/geopackage-android.git'
+                            developerConnection 'scm:git:git@github.com:ngageoint/geopackage-android.git'
+                        }
+
+                        licenses {
+                            license {
+                                name 'The MIT License (MIT)'
+                                url 'https://github.com/ngageoint/geopackage-android/blob/master/LICENSE.txt'
+                                distribution 'repo'
+                            }
+                        }
+
+                        organization {
+                            name 'National Geospatial-Intelligence Agency'
+                            url 'https://www.nga.mil'
+                        }
+
+                        developers {
+                            developer {
+                                id 'bosborn'
+                                name 'Brian Osborn'
+                                email 'osbornb@bit-sys.com'
+                                organizationUrl 'https://www.bit-sys.com'
+                                roles {
+                                    role 'developer'
+                                }
+                                timezone 'UTC-07'
+                            }
+                        }
+                    }
+                }
             }
-        }
-        artifacts {
-            archives sourceJar
         }
     }
 
-    /*
-    uploadArchives {
-        repositories {
-            mavenDeployer {
-                repository(
-                        url: "${nexusUrl}/content/repositories/releases") {
-                    authentication(userName: nexusUsername, password: nexusPassword)
-                }
-                snapshotRepository(
-                        url: "${nexusUrl}/content/repositories/snapshots") {
-                    authentication(userName: nexusUsername, password: nexusPassword)
-                }
-                pom.artifactId = 'geopackage-android'
-            }
-        }
-    }
-    */
 }
 
 dependencies {

--- a/geopackage-sdk/src/main/java/mil/nga/geopackage/GeoPackageCache.java
+++ b/geopackage-sdk/src/main/java/mil/nga/geopackage/GeoPackageCache.java
@@ -1,0 +1,39 @@
+package mil.nga.geopackage;
+
+/**
+ * GeoPackage Cache
+ *
+ * @author osbornb
+ */
+public class GeoPackageCache extends GeoPackageCoreCache<GeoPackage> {
+
+    /**
+     * GeoPackage manager
+     */
+    private GeoPackageManager manager;
+
+    /**
+     * Constructor
+     *
+     * @param manager
+     */
+    public GeoPackageCache(GeoPackageManager manager) {
+        this.manager = manager;
+    }
+
+    /**
+     * Get the cached GeoPackage or open and cache the GeoPackage
+     *
+     * @param name
+     * @return
+     */
+    public GeoPackage getOrOpen(String name) {
+        GeoPackage geoPackage = get(name);
+        if (geoPackage == null) {
+            geoPackage = manager.open(name);
+            add(geoPackage);
+        }
+        return geoPackage;
+    }
+
+}

--- a/geopackage-sdk/src/main/java/mil/nga/geopackage/GeoPackageManager.java
+++ b/geopackage-sdk/src/main/java/mil/nga/geopackage/GeoPackageManager.java
@@ -23,6 +23,13 @@ public interface GeoPackageManager {
     public List<String> databases();
 
     /**
+     * List all external GeoPackage databases sorted alphabetically
+     *
+     * @return external database list
+     */
+    public List<String> externalDatabases();
+
+    /**
      * Get the count of GeoPackage databases
      *
      * @return
@@ -35,6 +42,13 @@ public interface GeoPackageManager {
      * @return database set
      */
     public Set<String> databaseSet();
+
+    /**
+     * Set of all external GeoPackage databases
+     *
+     * @return external database set
+     */
+    public Set<String> externalDatabaseSet();
 
     /**
      * Determine if the database exists
@@ -91,6 +105,20 @@ public interface GeoPackageManager {
      * @return true if deleted
      */
     public boolean delete(String database);
+
+    /**
+     * Delete all databases
+     *
+     * @return true if deleted
+     */
+    public boolean deleteAll();
+
+    /**
+     * Delete all external GeoPackages
+     *
+     * @return true if deleted
+     */
+    public boolean deleteAllExternal();
 
     /**
      * Create a new GeoPackage database

--- a/geopackage-sdk/src/main/java/mil/nga/geopackage/factory/GeoPackageManagerImpl.java
+++ b/geopackage-sdk/src/main/java/mil/nga/geopackage/factory/GeoPackageManagerImpl.java
@@ -73,6 +73,18 @@ class GeoPackageManagerImpl implements GeoPackageManager {
     /**
      * {@inheritDoc}
      */
+    @Override
+    public List<String> externalDatabases() {
+        Set<String> sortedDatabases = new TreeSet<String>();
+        addExternalDatabases(sortedDatabases);
+        List<String> databases = new ArrayList<String>();
+        databases.addAll(sortedDatabases);
+        return databases;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public int count() {
         return context.databaseList().length;
     }
@@ -84,6 +96,16 @@ class GeoPackageManagerImpl implements GeoPackageManager {
     public Set<String> databaseSet() {
         Set<String> databases = new HashSet<String>();
         addDatabases(databases);
+        return databases;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<String> externalDatabaseSet() {
+        Set<String> databases = new HashSet<String>();
+        addExternalDatabases(databases);
         return databases;
     }
 
@@ -184,6 +206,36 @@ class GeoPackageManagerImpl implements GeoPackageManager {
         if (!external) {
             deleted = context.deleteDatabase(database);
         }
+        return deleted;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean deleteAll(){
+
+        boolean deleted = true;
+
+        for(String database: databaseSet()){
+            deleted = delete(database) && deleted;
+        }
+
+        return deleted;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean deleteAllExternal(){
+
+        boolean deleted = true;
+
+        for(String database: externalDatabaseSet()){
+            deleted = delete(database) && deleted;
+        }
+
         return deleted;
     }
 
@@ -580,6 +632,16 @@ class GeoPackageManagerImpl implements GeoPackageManager {
             }
         }
 
+        // Add the external databases
+        addExternalDatabases(databases);
+    }
+
+    /**
+     * Add all external databases to the collection
+     *
+     * @param databases
+     */
+    private void addExternalDatabases(Collection<String> databases) {
         // Get the external GeoPackages, adding those where the file exists and
         // deleting those with missing files
         List<GeoPackageMetadata> externalGeoPackages = getExternalGeoPackages();


### PR DESCRIPTION
- Central Repository version 1.0.0, artifact group id and name changed to:
mil.nga.geopackage:geopackage-android:1.0.0
- GeoPackage Cache implementation for managing open GeoPackages
- Query and deletion methods to return or delete only external GeoPackage files